### PR TITLE
Icons do not load in Safari when browsing from http://localhost

### DIFF
--- a/src/box-icon-element.js
+++ b/src/box-icon-element.js
@@ -81,7 +81,7 @@ export class BoxIconElement extends HTMLElement {
   static get cdnUrl() {
       // BUILD.DATA.VERSION is injected by webpack during a build.
       // Value is same as package.json#version property.
-    return `//unpkg.com/boxicons@${BUILD.DATA.VERSION}/svg`;
+    return `https://unpkg.com/boxicons@${BUILD.DATA.VERSION}/svg`;
   }
     /**
      * The html tag name to be use


### PR DESCRIPTION
Icons do not load in Safari when browsing from http://localhost (CORS error due to unpkg.com's 307 Temporary Redirect)

By using `//` you are matching the host's protocol.  This is usually a nice thing, but considering that http://unpkg.com links always 307 temporary redirects to the secure https:// version, it can only pose issues when (a) loading from a http:// context (i.e. http://localhost:4200) with (b) browsers that are more strict like Safari that throws a CORS error when it notices that the resource was redirected (even though it's the same domain and only redirecting from from http:// to https://).