### PR TITLE
Fix Issue #759 Let element exist in DOM before grabbing attribute (fix logo icon load issue)

### DIFF
--- a/src/box-icon-element.js
+++ b/src/box-icon-element.js
@@ -162,7 +162,6 @@ export class BoxIconElement extends HTMLElement {
     }
     this._state = {
       $iconHolder: this.$ui.getElementById('icon'),
-      type: this.getAttribute('type')
     };
   }
 
@@ -211,6 +210,9 @@ export class BoxIconElement extends HTMLElement {
   }
 
   connectedCallback() {
+      this._state = {
+          type: this.getAttribute('type')
+      };
       if (usingShadyCss()) {
         GLOBAL.ShadyCSS.styleElement(this);
       }


### PR DESCRIPTION
Otherwise original code will initiate fallback process prematurely by attempting to grab the same icon in other logo types (which doesn't really make sense for logos anyway, but this should at least stop the prevailing issue).